### PR TITLE
Change to MVVM Approach

### DIFF
--- a/Task Check-in.xcodeproj/project.pbxproj
+++ b/Task Check-in.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A0514C681C2ADEDB00B1FE6E /* VenueDetailViewController+UITableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0514C671C2ADEDB00B1FE6E /* VenueDetailViewController+UITableViewDataSource.swift */; };
 		A07212B21C2A394A0065A77A /* LocaltionTableViewController+UISearchResultsUpdating.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07212B11C2A394A0065A77A /* LocaltionTableViewController+UISearchResultsUpdating.swift */; };
 		A07212B41C2A3AA00065A77A /* LocaltionTableViewController+UISearchControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07212B31C2A3AA00065A77A /* LocaltionTableViewController+UISearchControllerDelegate.swift */; };
+		A0C7B3141C2BF5D70024A254 /* VenueViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C7B3131C2BF5D70024A254 /* VenueViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 		A0514C671C2ADEDB00B1FE6E /* VenueDetailViewController+UITableViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VenueDetailViewController+UITableViewDataSource.swift"; sourceTree = "<group>"; };
 		A07212B11C2A394A0065A77A /* LocaltionTableViewController+UISearchResultsUpdating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LocaltionTableViewController+UISearchResultsUpdating.swift"; sourceTree = "<group>"; };
 		A07212B31C2A3AA00065A77A /* LocaltionTableViewController+UISearchControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LocaltionTableViewController+UISearchControllerDelegate.swift"; sourceTree = "<group>"; };
+		A0C7B3131C2BF5D70024A254 /* VenueViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VenueViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 		A00F8D8F1C2938C100E6FC91 /* Task Check-in */ = {
 			isa = PBXGroup;
 			children = (
+				A0C7B3121C2BF5C30024A254 /* ViewModel */,
 				A00F8DB91C29585100E6FC91 /* Model */,
 				A00F8DA21C293B8A00E6FC91 /* Foursquare */,
 				A00F8DBA1C295DC600E6FC91 /* Store */,
@@ -196,6 +199,14 @@
 				A0514C671C2ADEDB00B1FE6E /* VenueDetailViewController+UITableViewDataSource.swift */,
 			);
 			name = VenueDetailViewController;
+			sourceTree = "<group>";
+		};
+		A0C7B3121C2BF5C30024A254 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				A0C7B3131C2BF5D70024A254 /* VenueViewModel.swift */,
+			);
+			name = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -336,6 +347,7 @@
 				A0514C5F1C29AF1700B1FE6E /* Route.swift in Sources */,
 				A07212B41C2A3AA00065A77A /* LocaltionTableViewController+UISearchControllerDelegate.swift in Sources */,
 				A00F8DA61C293C1000E6FC91 /* FoursquareRouter.swift in Sources */,
+				A0C7B3141C2BF5D70024A254 /* VenueViewModel.swift in Sources */,
 				A00F8DB61C294C9800E6FC91 /* LocaltionTableViewController+CLLocationManagerDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Task Check-in/Venue.swift
+++ b/Task Check-in/Venue.swift
@@ -26,7 +26,7 @@ struct Venue {
     /// A short URL for this venue, e.g. http://4sq.com/Ab123D
     var shortUrl: String = ""
     
-    var photoURLString: String?
+    var photoUrl: String?
     
     // This is just for a demonstration.
     // We can add more properties here, for example,
@@ -49,16 +49,9 @@ struct Venue {
             let prefix = photoJSON["prefix"].stringValue
             let suffix = photoJSON["suffix"].stringValue
             
-            photoURLString = prefix + "original" + suffix
+            photoUrl = prefix + "original" + suffix
         }
         
-    }
-    
-    
-    /// A url of venue's photo.
-    var photoUrl: NSURL?{
-        guard let photoURLString = photoURLString else { return nil }
-        return NSURL(string: photoURLString)
     }
     
 }

--- a/Task Check-in/VenueDetailViewController+UITableViewDataSource.swift
+++ b/Task Check-in/VenueDetailViewController+UITableViewDataSource.swift
@@ -14,8 +14,15 @@ extension VenueDetailViewController: UITableViewDataSource{
         
         let cell = tableView.dequeueReusableCellWithIdentifier("UITableViewCell")!
         
-        let item = itemsToShow[indexPath.row]
-        cell.textLabel?.text = "\(item.title): \(item.detail)"
+        if let venueViewModel = venueViewModel
+        {
+            let item = venueViewModel.itemsToShow[indexPath.row]
+            cell.textLabel?.text = "\(item.title): \(item.detail)"
+            
+        }else{
+            cell.textLabel?.text = "Nothing 😅"
+        }
+
         
         return cell
     }
@@ -25,7 +32,7 @@ extension VenueDetailViewController: UITableViewDataSource{
     }
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return itemsToShow.count
+        return venueViewModel?.itemsToShow.count ?? 0
     }
     
 }

--- a/Task Check-in/VenueDetailViewController.swift
+++ b/Task Check-in/VenueDetailViewController.swift
@@ -16,28 +16,22 @@ class VenueDetailViewController: UIViewController {
     // ------------------------------------------------------------
     // MARK: - States
     
-    var venue: Venue?{
+    var venueViewModel: VenueViewModel?{
         didSet{
-            guard let venue = venue else { return }
             
-            title = venue.name
-            
-            if let photoUrl = venue.photoUrl{
-                fetchVenuePhoto(url: photoUrl)
+            if let venueViewModel = venueViewModel{
+                
+                title = venueViewModel.name
+                
+                if let photoUrl = venueViewModel.photoUrl{
+                    fetchVenuePhoto(url: photoUrl)
+                }
             }
             
-            let titles = ["ID","Name","Description","Tags"]
-            let details = [venue.id, venue.name, venue.description, venue.tags.joinWithSeparator(", ")]
-            
-            itemsToShow = zip(titles, details).map{ (title: $0, detail: $1 ) }
-        }
-    }
-    
-    var itemsToShow: [ (title: String, detail: String ) ] = []{
-        didSet{
             tableView.reloadData()
         }
     }
+    
     // ------------------------------------------------------------
     // MARK: -
 
@@ -63,7 +57,9 @@ class VenueDetailViewController: UIViewController {
         foursquare
             .responseFromRoute(route, accessToken: UserStore.defaultStore.currentUserToken)
             .onSuccess{ json in
-                self.venue = Venue(json: json["response"]["venue"])
+                
+                let venue = Venue(json: json["response"]["venue"])
+                self.venueViewModel = VenueViewModel(venue: venue)
             }
             .onFail{ error in
                 print("can't get venue detail: \(error)")

--- a/Task Check-in/VenueViewModel.swift
+++ b/Task Check-in/VenueViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  VenueViewModel.swift
+//  Task Check-in
+//
+//  Created by Nutchaphon Rewik on 24/12/2015.
+//  Copyright © 2015 Nutchaphon Rewik. All rights reserved.
+//
+
+import Foundation
+
+class VenueViewModel{
+    
+    var name: String
+    var photoUrl: NSURL?
+    var itemsToShow: [ (title: String, detail: String ) ]
+    
+    init(venue: Venue){
+        
+        let titles = ["ID","Name","Description","Tags"]
+        let details = [venue.id, venue.name, venue.description, venue.tags.joinWithSeparator(", ")]
+        
+        itemsToShow = zip(titles, details).map{ (title: $0, detail: $1 ) }
+        
+        if let venuePhotoUrl = venue.photoUrl{
+            photoUrl = NSURL(string: venuePhotoUrl)
+        }
+        
+        name = venue.name
+    }
+    
+}


### PR DESCRIPTION
My thought on MVVM and MVC.

**MVVM introduces `ViewModel` layer.**

In typical MVC, When we want to present data on UI. We use `Controller` to do coordinating between `Model` and `View`. We need to transform the model data into presentable UI. For example, If we have `NSDate` in the model, what we have to do is converting it into readable format string and present it on View. This work is done in `Controller`.

However, when having too much data to present ( also other things ). `Controller` will quickly become mess. So, in this situation what MVVM help us is it separates presentation logic into a layer called `ViewModel`. This layer represents the presentation data. It's attached to `Model` in its domain. We transfer presentation logic to `ViewModel`, instead of doing it all in `Controller`.

**Responsibility**
- In typical MVC. `Model`<->`Controller`<->`View`. 
- Now to the MVVM in iOS. `Model`<->`ViewModel`<-> (`ViewController`<->`View`)
